### PR TITLE
Fix links to topo and dtopo files

### DIFF
--- a/examples/tsunami/tohoku/maketopo.py
+++ b/examples/tsunami/tohoku/maketopo.py
@@ -33,18 +33,18 @@ def get_topo(makeplots=False):
     clawpack.clawutil.data.get_remote_file(url, output_dir=scratch_dir, 
             file_name=topo_fname, verbose=True)
 
-    # topo_fname = 'hawaii_6s.txt'
-    # url = 'http://depts.washington.edu/clawpack/geoclaw/topo/etopo/' + topo_fname
-    # clawpack.clawutil.data.get_remote_file(url, output_dir=scratch_dir, 
-    #         file_name=topo_fname, verbose=True)
-
-    topo_fname = 'kahului_1s.txt'
-    url = 'http://depts.washington.edu/clawpack/geoclaw/topo/etopo/' + topo_fname
+    topo_fname = 'hawaii_6s.txt'
+    url = 'http://depts.washington.edu/clawpack/geoclaw/topo/hawaii/' + topo_fname
     clawpack.clawutil.data.get_remote_file(url, output_dir=scratch_dir, 
             file_name=topo_fname, verbose=True)
 
-    topo_fname = 'Fujii.txydz'
-    url = 'http://depts.washington.edu/clawpack/geoclaw/topo/dtopo/' + topo_fname
+    topo_fname = 'kahului_1s.txt'
+    url = 'http://depts.washington.edu/clawpack/geoclaw/topo/hawaii/' + topo_fname
+    clawpack.clawutil.data.get_remote_file(url, output_dir=scratch_dir, 
+            file_name=topo_fname, verbose=True)
+
+    topo_fname = 'fujii.txydz'
+    url = 'http://depts.washington.edu/clawpack/geoclaw/dtopo/tohoku/' + topo_fname
     clawpack.clawutil.data.get_remote_file(url, output_dir=scratch_dir, 
             file_name=topo_fname, verbose=True)
 

--- a/examples/tsunami/tohoku/setrun.py
+++ b/examples/tsunami/tohoku/setrun.py
@@ -421,7 +421,7 @@ def setgeo(rundata):
     # == settopo.data values ==
     topofiles = rundata.topo_data.topofiles
     topofiles.append([3, 1, 1, 0.0, 1e10, os.path.join(topodir,'etopo1min130E210E0N60N.asc')])
-    # topofiles.append([3, 1, 1, 0.0, 1e10, os.path.join(topodir,'hawaii_6s.txt')])
+    topofiles.append([3, 1, 1, 0.0, 1e10, os.path.join(topodir,'hawaii_6s.txt')])
     topofiles.append([3, 1, 1, 0., 1.e10, os.path.join(topodir,'kahului_1s.txt')])
 
 
@@ -429,7 +429,7 @@ def setgeo(rundata):
     # [dtype, minlevel, maxlevel, 'topo']
 
     # Region 1, above handles this region.  
-    rundata.dtopo_data.dtopofiles = [[1, 1, 1, os.path.join(topodir,'Fujii.txydz')]]
+    rundata.dtopo_data.dtopofiles = [[1, 1, 1, os.path.join(topodir,'fujii.txydz')]]
 
     # == setqinit.data values ==
     rundata.qinit_data.qinit_type =  0
@@ -454,5 +454,8 @@ def setgeo(rundata):
 if __name__ == '__main__':
     # Set up run-time parameters and write all data files.
     import sys
+    from clawpack.geoclaw import kmltools
     rundata = setrun(*sys.argv[1:])
     rundata.write()
+
+    kmltools.make_input_data_kmls(rundata)


### PR DESCRIPTION
The topo and dtopo files were already on the clawpack/geoclaw server, but some of the URLs were wrong.  This fixes them.